### PR TITLE
Updated autoform dependency to aldeed:autoform@5.0.0

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'yogiben:autoform-map',
   summary: 'Edit location coordinates with autoForm',
-  version: '0.0.3',
+  version: '0.0.4',
   git: 'https://github.com/yogiben/meteor-autoform-map'
 });
 
@@ -12,7 +12,7 @@ Package.onUse(function(api) {
   	'coffeescript',
   	'templating',
     'reactive-var',
-  	'aldeed:autoform@4.2.2',
+  	'aldeed:autoform@5.0.0',
   	'mrt:googlemaps@0.0.2'
   ], 'client');
 


### PR DESCRIPTION
yogiben:autoform-map works with the latest aldeed:autoform@5.0.0.

I did not test it extensively, but it works in my app as with the previous yogiben:autoform-map.