### PR TITLE
Support [Number] for GeoJSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,19 @@ Schemas.Cities = new SimpleSchema
 		decimal: true
 ```
 
+Or if you want to save lat and lng as a array, important for GEOJson:
+
+```
+Schemas.Cities = new SimpleSchema
+	location:
+		type: [Number]
+		decimal: true
+		autoform:
+			type: 'map'
+			afFieldInput:
+				# options
+```
+
 ### Options ###
 
 *mapType* type of google map. Possible values: `'roadmap' 'satellite' 'hybrid' 'terrain'`

--- a/lib/client/autoform-map.coffee
+++ b/lib/client/autoform-map.coffee
@@ -62,7 +62,7 @@ initTemplateAndGoogleMaps = ->
 	@data.map = new google.maps.Map @find('.js-map'), mapOptions
 
 	if @data.value
-		location = if typeof @data.value == 'string' then @data.value.split ',' else if typeof @data.value == 'Array' then [@data.value.lat, @data.value.lng] else [@data.value[1],@data.value[0]]
+		location = if typeof @data.value == 'string' then @data.value.split ',' else if @data.value.hasOwnProperty 'lat' then [@data.value.lat, @data.value.lng] else [@data.value[1],@data.value[0]]
 		location = new google.maps.LatLng parseFloat(location[0]), parseFloat(location[1])
 		@data.setMarker @data.map, location, @data.options.zoom
 		@data.map.setCenter location

--- a/lib/client/autoform-map.coffee
+++ b/lib/client/autoform-map.coffee
@@ -29,6 +29,8 @@ AutoForm.addInputType 'map',
 				"#{value.lng},#{value.lat}"
 			else
 				"#{value.lat},#{value.lng}"
+		numberArray: (value) ->
+			[value.lng, value.lat]
 
 Template.afMap.created = ->
 	GoogleMaps.load(libraries: 'places')
@@ -60,7 +62,7 @@ initTemplateAndGoogleMaps = ->
 	@data.map = new google.maps.Map @find('.js-map'), mapOptions
 
 	if @data.value
-		location = if typeof @data.value == 'string' then @data.value.split ',' else [@data.value.lat, @data.value.lng]
+		location = if typeof @data.value == 'string' then @data.value.split ',' else if typeof @data.value == 'Array' then [@data.value.lat, @data.value.lng] else [@data.value[1],@data.value[0]]
 		location = new google.maps.LatLng parseFloat(location[0]), parseFloat(location[1])
 		@data.setMarker @data.map, location, @data.options.zoom
 		@data.map.setCenter location


### PR DESCRIPTION
Important for GeoJSON

Example for GeoJSON with autoform

```javascript
geometry: {
	type: Object,
	optional: true
},
"geometry.type": {
	type: String,
	allowedValues: ["Point", "LineString", "Polygon"],
	autoValue: function() {
		if (this.isInsert) {
			return "Point";
		}
	}
},
"geometry.coordinates": {
	type: [Number],
	decimal: true,
	autoform: {
		type: 'map'
	}
}
```